### PR TITLE
:sparkles: extend custom validator fuctionality

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ import React, {
 export type Rules = {
   rulesMap: { [key: string]: string[] },
   role: string,
-  validator?: ({ role, rulesMap, name }: Rules & { name: string }) => boolean,
+  validator?: ({ role, rulesMap, name, permissions }: Rules & { name: string, permissions?: { [key:string]: string } }) => boolean,
 };
 
 const RoleContext: Context<Rules> = createContext({
@@ -28,6 +28,7 @@ type ProviderProps = {
 type ConsumerProps = {
   children: ReactChild,
   name: string,
+  permissions?: { [key: string]: string }, // any object that describes the permissions, which will be used in custom validator
 };
 
 export function PermissionGateProvider({ children, role, rulesMap }: ProviderProps): ReactElement {
@@ -45,15 +46,15 @@ const hasPermission = ({ role, rulesMap, name }: Rules & { name: string }): bool
   return scope.includes(role);
 };
 
-export function usePermission(name: string): Rules & { granted: boolean } {
+export function usePermission(name: string, permissions?: { [key: string]: string }): Rules & { granted: boolean } {
   const { role, rulesMap, validator = hasPermission }: Rules = useContext(RoleContext);
 
-  const granted = validator({ role, rulesMap, name });
+  const granted = validator({ role, rulesMap, name, permissions });
   return { granted, role, rulesMap };
 }
 
-function Gate({ children, name, ...other }: ConsumerProps, ref: Ref<HTMLElement>) {
-  const { granted } = usePermission(name);
+function Gate({ children, name, permissions, ...other }: ConsumerProps, ref: Ref<HTMLElement>) {
+  const { granted } = usePermission(name, permissions);
 
   if (!granted) return null;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ const RoleContext: Context<Rules> = createContext({
 
 type ProviderProps = {
   children: ReactChild,
+  validator?: ({ role, rulesMap, name, permissions }: Rules & { name: string, permissions?: { [key:string]: string } }) => boolean,
 } & Rules;
 
 type ConsumerProps = {
@@ -31,9 +32,9 @@ type ConsumerProps = {
   permissions?: { [key: string]: string }, // any object that describes the permissions, which will be used in custom validator
 };
 
-export function PermissionGateProvider({ children, role, rulesMap }: ProviderProps): ReactElement {
+export function PermissionGateProvider({ children, role, rulesMap, validator }: ProviderProps): ReactElement {
   return (
-    <RoleContext.Provider value={{ role, rulesMap }}>
+    <RoleContext.Provider value={{ role, rulesMap, validator }}>
       {children}
     </RoleContext.Provider>
   )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,10 +10,15 @@ import React, {
   ReactElement,
 } from "react";
 
+export type PermissionObject = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any,
+}
+
 export type Rules = {
   rulesMap: { [key: string]: string[] },
   role: string,
-  validator?: ({ role, rulesMap, name, permissions }: Rules & { name: string, permissions?: { [key:string]: string } }) => boolean,
+  validator?: ({ role, rulesMap, name, permissions }: Rules & { name: string, permissions?: PermissionObject }) => boolean,
 };
 
 const RoleContext: Context<Rules> = createContext({
@@ -23,7 +28,7 @@ const RoleContext: Context<Rules> = createContext({
 
 type ProviderProps = {
   children: ReactChild,
-  validator?: ({ role, rulesMap, name, permissions }: Rules & { name: string, permissions?: { [key:string]: string } }) => boolean,
+  validator?: ({ role, rulesMap, name, permissions }: Rules & { name: string, permissions?: PermissionObject }) => boolean,
 } & Rules;
 
 type ConsumerProps = {
@@ -47,7 +52,7 @@ const hasPermission = ({ role, rulesMap, name }: Rules & { name: string }): bool
   return scope.includes(role);
 };
 
-export function usePermission(name: string, permissions?: { [key: string]: string }): Rules & { granted: boolean } {
+export function usePermission(name: string, permissions?: PermissionObject): Rules & { granted: boolean } {
   const { role, rulesMap, validator = hasPermission }: Rules = useContext(RoleContext);
 
   const granted = validator({ role, rulesMap, name, permissions });


### PR DESCRIPTION
Extend custom validator fuctionality.
I need use users fields as permissions, for example i have user `{ calendarAccess: true, ... }`, so access to resources describes not only by roles, and also user specific permissions.
My custom validator will be looks like:
```
export const permissionsValidator = ({
 role, rulesMap: rules, name, permissions,
}: Rules & { name: string }): boolean => {
  const scope = rules[name];
  if (!scope) return true;

  if (role === 'PARTNER' && name === components.calendar) {
    return scope.includes(role) && permissions.calendarAccess;
  }

  return scope.includes(role);
};
```
So in this approach i can limit access more flexible.