### PR TITLE
Fix PermissionGate context provider bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "permission-gate",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A library for handling roles and permissions in large-scale React apps",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import React, {
   isValidElement,
   Context,
   Ref,
-  ReactChild,
+  ReactNode,
   ReactElement,
 } from "react";
 
@@ -23,11 +23,11 @@ const RoleContext: Context<Rules> = createContext({
 });
 
 type ProviderProps = {
-  children: ReactChild,
+  children: ReactNode,
 } & Rules;
 
 type ConsumerProps = {
-  children: ReactChild,
+  children: ReactNode,
   name: string,
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true
   },
   "include": ["src"],


### PR DESCRIPTION
The type definition didn't match the actual implementation.
This PR addresses it.